### PR TITLE
Remove  Redundant Empty Provider Block

### DIFF
--- a/modules/random/Random-Password/versions.tf
+++ b/modules/random/Random-Password/versions.tf
@@ -17,5 +17,3 @@ terraform {
     }
   }
 }
-
-provider "random" {}


### PR DESCRIPTION
## Purpose

Resolving the following warning

```
│   on modules/common-terraform-modules/modules/random/Random-Password/versions.tf line 21:
│   21: provider "random" {}
│ 
│ Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider
│ configuration by their callers. That approach was ambiguous and is now deprecated.
│ 
│ If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "random" blocks and then adding or updating an entry
│ like the following to the required_providers block of module.url-mgt-db-admin-password:
│     random = {
│       source = "hashicorp/random"
│     }

```

## Related Issue

https://github.com/wso2-enterprise/choreo/issues/27550