### PR TITLE
Set the default format of a HashiCorp Vault PKI artifact certificate's private key

### DIFF
--- a/modules/vault/Vault-PKI-Secret-Backend-Certificate/variables.tf
+++ b/modules/vault/Vault-PKI-Secret-Backend-Certificate/variables.tf
@@ -60,7 +60,7 @@ variable "format" {
 variable "private_key_format" {
   description = "Private key's format"
   type        = string
-  default     = "pem"
+  default     = "pkcs8"
 }
 
 variable "min_seconds_remaining" {


### PR DESCRIPTION
## Purpose
https://github.com/wso2-enterprise/choreo/issues/35953
Identified during the application of https://github.com/wso2-enterprise/choreo-deployment/pull/4142

## Goals
$subject

## Approach
Using Terraform IaC, the PKI artifacts are expected to be managed