### PR TITLE
Incraese vault_auth_backend (approle) max-lease-ttl to 5 years

### DIFF
--- a/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
+++ b/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
@@ -12,7 +12,7 @@
 resource "vault_auth_backend" "approle" {
   type = "approle"
   tune {
-    max_lease_ttl      = var.vault_auth_backend_max_lease_ttl
+    max_lease_ttl = var.vault_auth_backend_max_lease_ttl
   }
 }
 

--- a/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
+++ b/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
@@ -11,6 +11,9 @@
 
 resource "vault_auth_backend" "approle" {
   type = "approle"
+  tune {
+    max_lease_ttl      = "43800h"
+  }
 }
 
 resource "vault_approle_auth_backend_role" "app_role" {

--- a/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
+++ b/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
@@ -12,7 +12,7 @@
 resource "vault_auth_backend" "approle" {
   type = "approle"
   tune {
-    max_lease_ttl      = "43800h"
+    max_lease_ttl      = var.vault_auth_backend_max_lease_ttl
   }
 }
 

--- a/modules/vault/Vault-AppRole-Auth-Backend-Role/variables.tf
+++ b/modules/vault/Vault-AppRole-Auth-Backend-Role/variables.tf
@@ -50,3 +50,9 @@ variable "secret_id_num_uses" {
   description = "The number of seconds after which any SecretID expires"
   type        = number
 }
+
+variable "vault_auth_backend_max_lease_ttl" {
+  type        = string
+  default     = "43800h"
+  description = "Global max lease TTL for the Hashicorp vault auth backend"
+}


### PR DESCRIPTION
## Purpose
> Increase the vault approle auth backend max lease ttl to 5 years.

Related issue: https://github.com/wso2-enterprise/choreo/issues/36799