### PR TITLE
Create a Separate Module for vault_auth_backend

### DIFF
--- a/modules/vault/Dynamic-Vault-AppRole-Auth-Backend-Role/approle.tf
+++ b/modules/vault/Dynamic-Vault-AppRole-Auth-Backend-Role/approle.tf
@@ -9,16 +9,8 @@
 #
 # --------------------------------------------------------------------------------------
 
-resource "vault_auth_backend" "approle" {
-  type = "approle"
-  tune {
-    max_lease_ttl     = var.vault_auth_backend_max_lease_ttl
-    default_lease_ttl = var.vault_auth_backend_default_lease_ttl
-  }
-}
-
 resource "vault_approle_auth_backend_role" "app_role" {
-  backend            = vault_auth_backend.approle.path
+  backend            = var.backend
   role_name          = var.role_name
   token_policies     = var.token_policies
   bind_secret_id     = var.bind_secret_id
@@ -38,7 +30,7 @@ resource "time_rotating" "secret_id_2" {
 }
 
 resource "vault_approle_auth_backend_role_secret_id" "secret_id_1" {
-  backend   = vault_auth_backend.approle.path
+  backend   = var.backend
   role_name = vault_approle_auth_backend_role.app_role.role_name
   ttl       = var.secret_id_ttl
   metadata = jsonencode(
@@ -50,7 +42,7 @@ resource "vault_approle_auth_backend_role_secret_id" "secret_id_1" {
 }
 
 resource "vault_approle_auth_backend_role_secret_id" "secret_id_2" {
-  backend   = vault_auth_backend.approle.path
+  backend   = var.backend
   role_name = vault_approle_auth_backend_role.app_role.role_name
   ttl       = var.secret_id_ttl
   metadata = jsonencode(

--- a/modules/vault/Dynamic-Vault-AppRole-Auth-Backend-Role/variables.tf
+++ b/modules/vault/Dynamic-Vault-AppRole-Auth-Backend-Role/variables.tf
@@ -9,6 +9,11 @@
 #
 # --------------------------------------------------------------------------------------
 
+variable "backend" {
+  description = "The path where the AppRole auth backend is mounted"
+  type        = string
+}
+
 variable "role_name" {
   description = "Name of the App Role"
   type        = string
@@ -49,18 +54,6 @@ variable "token_max_ttl" {
 variable "secret_id_num_uses" {
   description = "The number of seconds after which any SecretID expires"
   type        = number
-}
-
-variable "vault_auth_backend_max_lease_ttl" {
-  type        = string
-  default     = "43800h"
-  description = "Global max lease TTL for the Hashicorp vault auth backend"
-}
-
-variable "vault_auth_backend_default_lease_ttl" {
-  type        = string
-  default     = "43800h"
-  description = "Global default lease TTL for the Hashicorp vault auth backend"
 }
 
 variable "secret_id_1_rotation_time_in_months" {

--- a/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
+++ b/modules/vault/Vault-AppRole-Auth-Backend-Role/approle.tf
@@ -9,16 +9,8 @@
 #
 # --------------------------------------------------------------------------------------
 
-resource "vault_auth_backend" "approle" {
-  type = "approle"
-  tune {
-    max_lease_ttl     = var.vault_auth_backend_max_lease_ttl
-    default_lease_ttl = var.vault_auth_backend_default_lease_ttl
-  }
-}
-
 resource "vault_approle_auth_backend_role" "app_role" {
-  backend            = vault_auth_backend.approle.path
+  backend            = var.backend
   role_name          = var.role_name
   token_policies     = var.token_policies
   bind_secret_id     = var.bind_secret_id
@@ -30,7 +22,7 @@ resource "vault_approle_auth_backend_role" "app_role" {
 }
 
 resource "vault_approle_auth_backend_role_secret_id" "secret_id" {
-  backend   = vault_auth_backend.approle.path
+  backend   = var.backend
   role_name = vault_approle_auth_backend_role.app_role.role_name
   ttl       = var.secret_id_ttl
 }

--- a/modules/vault/Vault-AppRole-Auth-Backend-Role/variables.tf
+++ b/modules/vault/Vault-AppRole-Auth-Backend-Role/variables.tf
@@ -9,6 +9,11 @@
 #
 # --------------------------------------------------------------------------------------
 
+variable "backend" {
+  description = "The path where the AppRole auth backend is mounted"
+  type        = string
+}
+
 variable "role_name" {
   description = "Name of the App Role"
   type        = string
@@ -49,16 +54,4 @@ variable "token_max_ttl" {
 variable "secret_id_num_uses" {
   description = "The number of seconds after which any SecretID expires"
   type        = number
-}
-
-variable "vault_auth_backend_max_lease_ttl" {
-  type        = string
-  default     = "43800h"
-  description = "Global max lease TTL for the Hashicorp vault auth backend"
-}
-
-variable "vault_auth_backend_default_lease_ttl" {
-  type        = string
-  default     = "43800h"
-  description = "Global default lease TTL for the Hashicorp vault auth backend"
 }

--- a/modules/vault/Vault-Auth-Backend/main.tf
+++ b/modules/vault/Vault-Auth-Backend/main.tf
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "vault_auth_backend" "auth_backend" {
+  type = var.type
+  tune {
+    max_lease_ttl     = var.max_lease_ttl
+    default_lease_ttl = var.default_lease_ttl
+  }
+}

--- a/modules/vault/Vault-Auth-Backend/outputs.tf
+++ b/modules/vault/Vault-Auth-Backend/outputs.tf
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "path" {
+  value      = vault_auth_backend.auth_backend.path
+  depends_on = [vault_auth_backend.auth_backend]
+}

--- a/modules/vault/Vault-Auth-Backend/variables.tf
+++ b/modules/vault/Vault-Auth-Backend/variables.tf
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "type" {
+  type        = string
+  description = "The type of the auth backend (e.g., 'userpass', 'ldap', 'jwt', etc.)"
+}
+
+variable "max_lease_ttl" {
+  type        = string
+  default     = "43800h"
+  description = "Global max lease TTL for the Hashicorp vault auth backend"
+}
+
+variable "default_lease_ttl" {
+  type        = string
+  default     = "43800h"
+  description = "Global default lease TTL for the Hashicorp vault auth backend"
+}

--- a/modules/vault/Vault-Auth-Backend/versions.tf
+++ b/modules/vault/Vault-Auth-Backend/versions.tf
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 4.8.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Embedding vault auth backend in the same module where the approle and secret id exists, prevents us from issuing new approles and secret IDs for the same backend. Hence, auth_backend will be moved out to a separate module